### PR TITLE
Fix error caused trying to apply focus to wrong text input ref

### DIFF
--- a/frontend/src/components/Say.js
+++ b/frontend/src/components/Say.js
@@ -24,7 +24,7 @@ class Say extends Component {
         return (
             <div>
                 <input
-                    ref={this.input}
+                    ref={this.textInput}
                     placeholder="Say" 
                     value={this.text} 
                     onChange={this.updateText} 


### PR DESCRIPTION
Incorrect ref was causing an error when submitting a new message because the `inputText` ref was undefined.